### PR TITLE
fix: pass options.directory to Eleventy Fetch AssetCache

### DIFF
--- a/eleventy-cache-webmentions.js
+++ b/eleventy-cache-webmentions.js
@@ -89,7 +89,7 @@ const fetchWebmentions = async (options) => {
 		throw new Error("uniqueKey is a required field when attempting to retrieve Webmentions. See https://chrisburnell.com/eleventy-cache-webmentions/#installation for more information.")
 	}
 
-	let asset = new AssetCache(options.uniqueKey)
+	let asset = new AssetCache(options.uniqueKey, options.directory)
 	asset.ensureDir()
 
 	let webmentions = []

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chrisburnell/eleventy-cache-webmentions",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Fetch and cache webmentions using eleventy-fetch.",
   "main": "eleventy-cache-webmentions.js",
   "author": "Chris Burnell <me@chrisburnell.com>",


### PR DESCRIPTION
Fixes #2.

I must have forgotten or removed the code that allows passing a `directory` key in `options` to Eleventy Fetch in order to instruct `AssetCache()` where to put the cached data. This PR enables the functionality described by the [documentation](https://chrisburnell.com/eleventy-cache-webmentions/#options).
