### PR TITLE
chore: update node-fetch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@11ty/eleventy-fetch": "^4.0.0",
     "lodash": "^4.17.21",
-    "node-fetch": "2.6.5",
+    "node-fetch": "^2.6.7",
     "sanitize-html": "^2.10.0"
   },
   "main": "eleventy-cache-webmentions.js",


### PR DESCRIPTION
 to be the same as that used by @11ty/eleventy-fetch

Fixes #.

node-fetch (<2.6.7) is vulnerable to Exposure of Sensitive Information to an Unauthorized Actor

change to allowed `node-fetch` package versions to enable maintainers to update their repositories to use non-vulnerable versions 

This is the same package reference definition for `node-fetch` as defined in the referenced `@11ty/eleventy-fetch` package
